### PR TITLE
feat: use 'Unknown' for enums that receive unexpected value

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "test:coverage-clover": "phpunit --coverage-clover coverage/clover.xml",
         "test:support": "phpunit --testsuite=Support",
         "test:exceptions": "phpunit --testsuite=Exceptions",
-        "analyse": "phpstan analyse",
+        "analyse": "phpstan analyse --memory-limit=512M",
         "cs:check": "pint --test src tests",
         "cs:fix": "pint src tests"
     },

--- a/src/Traits/HasTypeConversion.php
+++ b/src/Traits/HasTypeConversion.php
@@ -131,7 +131,11 @@ trait HasTypeConversion
             if (is_string($value) || is_int($value)) {
                 // For BackedEnum (with values)
                 if (is_subclass_of($typeName, BackedEnum::class)) {
-                    return $typeName::tryFrom($value);
+                    $enum = $typeName::tryFrom($value);
+                    if (null === $enum) {
+                        return self::defaultCase($typeName, 'Unknown');
+                    }
+                    return $enum;
                 }
 
                 // For UnitEnum (without values)
@@ -187,5 +191,22 @@ trait HasTypeConversion
         }
 
         return $value;
+    }
+
+    /**
+     * @template T of BackedEnum
+     * @param class-string<T> $enumClass
+     * @param string $caseName
+     * @return BackedEnum|null
+     */
+    private static function defaultCase(string $enumClass, string $caseName): ?BackedEnum
+    {
+        foreach ($enumClass::cases() as $case) {
+            if ($case->name === $caseName) {
+                return $case;
+            }
+        }
+
+        return null;
     }
 }

--- a/tests/Data/StatusTestEnum.php
+++ b/tests/Data/StatusTestEnum.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests\Data;
+
+enum StatusTestEnum: string
+{
+    case Active = 'active';
+    case Paused = 'paused';
+    case Inactive = 'inactive';
+    case Unknown = 'unknown';
+
+}

--- a/tests/Unit/Support/HydrationTestClass.php
+++ b/tests/Unit/Support/HydrationTestClass.php
@@ -2,20 +2,28 @@
 
 namespace Tests\Unit\Support;
 
+use DateTimeInterface;
 use Ninja\Granite\Mapping\Contracts\NamingConvention;
 use Ninja\Granite\Serialization\Attributes\DateTimeProvider;
 use Ninja\Granite\Traits\HasDeserialization;
+use Ninja\Granite\Traits\HasTypeConversion;
 use ReflectionProperty;
-use ReflectionType;
+use Tests\Data\StatusTestEnum;
 
 class HydrationTestClass
 {
     use HasDeserialization;
+    use HasTypeConversion;
 
     public string $noDefaultNonNullable;
     public string $defaultNonNullable = 'defaultNonNullable';
     public ?string $noDefaultNullable;
     public ?string $defaultNullable = 'defaultNullable';
+
+    public StatusTestEnum $requiredEnum;
+    public StatusTestEnum $defaultEnum = StatusTestEnum::Paused;
+    public ?StatusTestEnum $nullableEnum;
+    public ?StatusTestEnum $defaultNullableEnum = StatusTestEnum::Paused;
 
     public static function testHydrate(array $data): static
     {
@@ -52,12 +60,13 @@ class HydrationTestClass
         return array_key_exists($phpName, $data) ?? array_key_exists($serializedName, $data) ?? false;
     }
 
-    protected static function convertValueToType(
-        mixed $value,
-        ?ReflectionType $type,
-        ?ReflectionProperty $property = null,
-        ?DateTimeProvider $classProvider = null,
-    ): mixed {
-        return $value;
+    protected static function convertToCarbon(mixed $value, string $typeName, ?ReflectionProperty $property = null, ?DateTimeProvider $classProvider = null): ?DateTimeInterface
+    {
+        return null;
+    }
+
+    protected static function convertToDateTime(mixed $value, string $typeName, ?ReflectionProperty $property = null, ?DateTimeProvider $classProvider = null): ?DateTimeInterface
+    {
+        return null;
     }
 }


### PR DESCRIPTION
**Optional Feature**: Right now if you receive a value that is not in your backend enum, the app will crash.
Added special case for backed enum to set 'Unknown' value if these case is present, otherwhise the expected crash if property is not nullable