### PR TITLE
Performance optimizations & README reorganization

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,103 +14,31 @@
 
 A powerful, zero-dependency PHP library for building **immutable**, **serializable** objects with **validation** and **mapping** capabilities. Perfect for DTOs, Value Objects, API responses, and domain modeling.
 
-## 🪶 Pebble - NEW! Lightweight Immutable Snapshots
+## 🪶 Pebble - Lightweight Immutable Snapshots
 
-Need a quick immutable snapshot without validation overhead? Meet **Pebble** - a lightweight alternative perfect for:
-- Creating immutable snapshots of Eloquent models
-- Fast DTOs without validation or type definitions
-- Caching and comparison use cases
-- High-performance object comparisons with fingerprinting
+**Pebble** is a lightweight alternative to Granite for when you need immutable snapshots without validation overhead — ideal for caching, Eloquent snapshots, and fast comparisons.
 
 ```php
-use Ninja\Granite\Pebble;
+$snapshot = Pebble::from($eloquentModel);
 
-// Create an immutable snapshot from any object
-$user = User::query()->first();
-$snapshot = Pebble::from($user);
-
-// Access properties dynamically (both styles work!)
-echo $snapshot->name;        // Magic __get
-echo $snapshot['email'];     // ArrayAccess interface
-$count = count($snapshot);   // Countable interface
-
-// Fast O(1) comparisons with fingerprinting
-$snapshot1 = Pebble::from($user1);
-$snapshot2 = Pebble::from($user2);
-if ($snapshot1->equals($snapshot2)) {
-    // Uses cached hash for instant comparison!
-}
-
-// Get unique fingerprint for caching/comparison
-$hash = $snapshot->fingerprint(); // xxh3 hash
-
-// Immutable transformations
-$publicData = $snapshot->except(['password'])->merge(['status' => 'active']);
+$snapshot->name;           // Magic __get
+$snapshot['email'];        // ArrayAccess
+$snapshot->equals($other); // O(1) fingerprint comparison
 ```
-
-**Key Features:**
-- ⚡ **Fast comparisons** - O(1) equality checks using xxh3 fingerprinting
-- 🔑 **ArrayAccess** - Use both `$pebble->name` and `$pebble['name']` syntax
-- 📊 **Countable** - Native `count($pebble)` support
-- 🔒 **Immutable** - Cannot be modified after creation
-- 🚀 **Zero overhead** - No validation or type checking
-
-**When to use which:**
-- **Pebble** → Quick snapshots, no validation needed, dynamic properties, maximum performance, fast comparisons
-- **Granite** → Full DTOs with validation, type safety, custom serialization, advanced features
 
 📖 **[Read Pebble Documentation](docs/pebble.md)**
 
 ---
 
-This documentation has been generated almost in its entirety using 🦠 Claude 4 Sonnet based on source code analysis. Some sections may be incomplete, outdated or may contain documentation for planned or not-released features. For the most accurate information, please refer to the source code or open an issue on the package repository.
-
 ## ✨ Features
 
-### 🔒 **Immutable Objects**
-- Read-only DTOs and Value Objects
-- Thread-safe by design
-- Functional programming friendly
-
-### 🎯 **Enhanced Object Creation**
-- **Multiple `from()` patterns** - Array, JSON, named parameters, mixed usage
-- **Transparent operation** - No method overrides needed in child classes
-- **Type-safe** - Full PHPStan Level 10 compatibility
-- **Flexible usage** - Perfect for APIs, domain modeling, and clean code
-
-### ✅ **Comprehensive Validation**
-- 30+ built-in validation rules including Carbon date validation
-- Attribute-based validation (PHP 8+)
-- Custom validation rules and callbacks
-- Conditional and nested validation
-- **Carbon-specific rules** - Age, BusinessDay, Future, Past, Range, Weekend
-
-### 🔄 **Powerful ObjectMapper**
-- Automatic property mapping between objects
-- Convention-based mapping with multiple naming conventions
-- Custom transformations and collection mapping
-- Bidirectional mapping support
-
-### 📦 **Smart Serialization**
-- JSON/Array serialization with custom property names
-- Class-level naming conventions with `SerializationConvention` attribute
-- Hide sensitive properties automatically
-- **Carbon date handling** - Custom formats, relative parsing, timezone support
-- DateTime and Enum handling
-- Nested object serialization
-
-### 🔍 **Object Comparison**
-- Deep equality comparison with `equals()` method
-- Detailed difference detection with `differs()` method
-- Recursive comparison of nested objects and arrays
-- Timezone-aware DateTime comparison
-- Efficient array comparison without JSON encoding
-
-### ⚡ **Performance Optimized**
-- Fast path bypasses hydration pipeline for simple DTOs (~3.5x vs plain PHP)
-- WeakMap caching for `array()` and `json()` (near-native speed on repeated calls)
-- Reflection caching and O(1) hidden property lookups
-- Direct property access for serialization and comparison
+- **Immutable Objects** — Read-only DTOs and Value Objects, thread-safe by design
+- **Flexible `from()` Method** — Create from arrays, JSON, named parameters, other Granite objects, or mix them
+- **Comprehensive Validation** — 30+ built-in rules including Carbon date validation (Age, Future, Past, BusinessDay...)
+- **ObjectMapper** — Convention-based property mapping between objects with custom transformations
+- **Smart Serialization** — Custom property names, naming conventions, hidden fields, Carbon date formats
+- **Object Comparison** — Deep equality with `equals()`, detailed diffs with `differs()`
+- **Performance Optimized** — Fast path for simple DTOs (~3.5x vs plain PHP), WeakMap caching, direct property access
 
 ## 🚀 Quick Start
 
@@ -123,24 +51,15 @@ composer require diego-ninja/granite
 ### Basic Usage
 
 ```php
-<?php
-
 use Ninja\Granite\Granite;
 use Ninja\Granite\Validation\Attributes\Required;
 use Ninja\Granite\Validation\Attributes\Email;
 use Ninja\Granite\Validation\Attributes\Min;
-use Ninja\Granite\Serialization\Attributes\SerializedName;
-use Ninja\Granite\Serialization\Attributes\SerializationConvention;
 use Ninja\Granite\Serialization\Attributes\Hidden;
-use Ninja\Granite\Serialization\Attributes\CarbonDate;
-use Carbon\Carbon;
 
-// Create a Granite object with validation
 final readonly class User extends Granite
 {
     public function __construct(
-        public ?int $id,
-
         #[Required]
         #[Min(2)]
         public string $name,
@@ -149,571 +68,42 @@ final readonly class User extends Granite
         #[Email]
         public string $email,
 
-        #[Hidden] // Won't appear in JSON
+        #[Hidden]
         public ?string $password = null,
-
-        #[SerializedName('created_at')]
-        #[CarbonDate(format: 'Y-m-d H:i:s')]
-        public Carbon $createdAt = new Carbon()
     ) {}
 }
 
-// Multiple ways to create objects - all work transparently!
+// Create from array
+$user = User::from(['name' => 'John Doe', 'email' => 'john@example.com', 'password' => 'secret']);
 
-// 1. From array (traditional)
-$user = User::from([
-    'name' => 'John Doe',
-    'email' => 'john@example.com',
-    'password' => 'secret123'
-]);
-
-// 2. From JSON string
-$user = User::from('{"name": "John Doe", "email": "john@example.com", "password": "secret123"}');
-
-// 3. Named parameters (NEW!) - Works transparently without method overrides
-$user = User::from(
-    name: 'John Doe',
-    email: 'john@example.com',
-    password: 'secret123'
-);
-
-// 4. Mixed - base data with named overrides (NEW!)
-$baseData = ['name' => 'John', 'email' => 'john@example.com'];
-$user = User::from($baseData, name: 'John Doe', password: 'secret123');
-
-// 5. From another Granite object
-$anotherUser = User::from($user);
+// Create from named parameters
+$user = User::from(name: 'John Doe', email: 'john@example.com');
 
 // Immutable updates
-$updatedUser = $user->with(['name' => 'Jane Doe']);
+$updated = $user->with(['name' => 'Jane Doe']);
 
-// Serialization with Carbon support
-$json = $user->json();
-// {"id":null,"name":"John Doe","email":"john@example.com","created_at":"2024-01-15 10:30:00"}
-
+// Serialization (password hidden automatically)
+$json = $user->json();   // {"name":"John Doe","email":"john@example.com"}
 $array = $user->array();
-// password is hidden, created_at uses custom Carbon format
-```
-
-### 🎯 Enhanced `from()` Method
-
-Granite's `from()` method supports multiple invocation patterns **transparently** - no need to override methods in child classes!
-
-```php
-final readonly class Product extends Granite
-{
-    public function __construct(
-        public string $name,
-        public float $price,
-        public ?string $description = null,
-        #[CarbonDate]
-        public Carbon $createdAt = new Carbon()
-    ) {}
-}
-
-// All these patterns work automatically:
-
-// Array data
-$product = Product::from(['name' => 'Laptop', 'price' => 999.99]);
-
-// JSON string  
-$product = Product::from('{"name": "Laptop", "price": 999.99}');
-
-// Named parameters - perfect for APIs and clean code
-$product = Product::from(
-    name: 'Laptop',
-    price: 999.99,
-    description: 'High-performance laptop'
-);
-
-// Mixed patterns - base data + overrides
-$defaults = ['name' => 'Generic Product', 'price' => 0.0];
-$product = Product::from($defaults, name: 'Laptop', price: 999.99);
-
-// From another Granite object
-$clonedProduct = Product::from($product);
-
-// Partial data - unspecified properties remain uninitialized
-$partial = Product::from(name: 'Laptop', price: 999.99);
-// $partial->description is uninitialized, not null
-```
-
-### 📅 Carbon Date Support
-
-Granite includes comprehensive support for Carbon dates with specialized attributes:
-
-```php
-use Ninja\Granite\Serialization\Attributes\CarbonDate;
-use Ninja\Granite\Serialization\Attributes\CarbonRange;
-use Ninja\Granite\Serialization\Attributes\CarbonRelative;
-use Ninja\Granite\Validation\Rules\Carbon\Age;
-use Ninja\Granite\Validation\Rules\Carbon\Future;
-use Ninja\Granite\Validation\Rules\Carbon\BusinessDay;
-
-final readonly class Event extends Granite  
-{
-    public function __construct(
-        public string $title,
-        
-        // Custom date format for serialization
-        #[CarbonDate(format: 'd/m/Y H:i')]
-        public Carbon $startDate,
-        
-        // Date range validation
-        #[CarbonRange(min: 'now', max: '+1 year')]
-        public Carbon $endDate,
-        
-        // Relative date parsing ('tomorrow', '2 weeks ago', etc.)
-        #[CarbonRelative]
-        public ?Carbon $reminderDate = null,
-        
-        // Business logic validation
-        #[Future(message: 'Event must be in the future')]
-        #[BusinessDay(message: 'Event must be on a business day')]
-        public Carbon $publishDate
-    ) {}
-}
-
-// Create with various date formats
-$event = Event::from(
-    title: 'Conference',
-    startDate: '2024-12-25 09:00:00',     // Standard format
-    endDate: Carbon::parse('+3 days'),     // Carbon object
-    reminderDate: 'tomorrow at 9am',       // Relative format
-    publishDate: '2024-12-01'              // Date only
-);
-
-// Serialization uses custom formats
-$json = $event->json();
-// {"title":"Conference","startDate":"25/12/2024 09:00",...}
-```
-
-### Serialization Conventions
-
-Apply naming conventions to all properties in a class during serialization:
-
-```php
-use Ninja\Granite\Mapping\Conventions\SnakeCaseConvention;
-use Ninja\Granite\Serialization\Attributes\SerializationConvention;
-
-#[SerializationConvention(SnakeCaseConvention::class)]
-final readonly class UserProfile extends Granite
-{
-    public function __construct(
-        public string $firstName,      // serialized as "first_name"
-        public string $lastName,       // serialized as "last_name"
-        public string $emailAddress,   // serialized as "email_address"
-
-        #[SerializedName('user_id')]   // explicit name takes precedence
-        public int $id
-    ) {}
-}
-
-$profile = new UserProfile('John', 'Doe', 'john@example.com', 123);
-$json = $profile->json();
-// {"first_name":"John","last_name":"Doe","email_address":"john@example.com","user_id":123}
-```
-
-### 🔍 Object Comparison
-
-Compare Granite objects for equality or detect specific differences:
-
-```php
-use Ninja\Granite\Granite;
-
-final readonly class User extends Granite
-{
-    public function __construct(
-        public int $id,
-        public string $name,
-        public string $email,
-        public ?DateTime $lastLogin = null
-    ) {}
-}
-
-// Create two user instances
-$user1 = User::from(['id' => 1, 'name' => 'John Doe', 'email' => 'john@example.com']);
-$user2 = User::from(['id' => 1, 'name' => 'John Doe', 'email' => 'john@example.com']);
-$user3 = User::from(['id' => 1, 'name' => 'Jane Doe', 'email' => 'jane@example.com']);
-
-// Check equality
-$user1->equals($user2); // true - all properties match
-$user1->equals($user3); // false - name and email differ
-
-// Get detailed differences
-$differences = $user1->differs($user3);
-// [
-//     'name' => ['current' => 'John Doe', 'new' => 'Jane Doe'],
-//     'email' => ['current' => 'john@example.com', 'new' => 'jane@example.com']
-// ]
-
-// Works with nested objects
-$post1 = Post::from([
-    'title' => 'My Post',
-    'author' => User::from(['id' => 1, 'name' => 'John', 'email' => 'john@example.com'])
-]);
-
-$post2 = Post::from([
-    'title' => 'My Post',
-    'author' => User::from(['id' => 2, 'name' => 'Jane', 'email' => 'jane@example.com'])
-]);
-
-$differences = $post1->differs($post2);
-// [
-//     'author' => [
-//         'id' => ['current' => 1, 'new' => 2],
-//         'name' => ['current' => 'John', 'new' => 'Jane'],
-//         'email' => ['current' => 'john@example.com', 'new' => 'jane@example.com']
-//     ]
-// ]
 ```
 
 ## 📖 Documentation
 
 ### Core Concepts
 
-- **[Enhanced from() Method](docs/hydration.md)** - Multiple invocation patterns for flexible object creation ✨ NEW
-- **[Validation](docs/validation.md)** - Comprehensive validation system with 30+ built-in rules including Carbon
-- **[Serialization](docs/serialization.md)** - Control how objects are converted to/from arrays and JSON with Carbon support
-- **[Object Comparison](docs/comparison.md)** - Deep equality checks and difference detection ✨ NEW
-- **[ObjectMapper](docs/automapper.md)** - Powerful object-to-object mapping with conventions
-- **[Advanced Usage](docs/advanced_usage.md)** - Patterns for complex applications
-- **[API Reference](docs/api_reference.md)** - Complete API documentation with new Carbon features
-
+- **[Enhanced from() Method](docs/hydration.md)** — Multiple invocation patterns for flexible object creation
+- **[Validation](docs/validation.md)** — Comprehensive validation system with 30+ built-in rules including Carbon
+- **[Serialization](docs/serialization.md)** — Control how objects are converted to/from arrays and JSON with Carbon support
+- **[Object Comparison](docs/comparison.md)** — Deep equality checks and difference detection
+- **[ObjectMapper](docs/automapper.md)** — Powerful object-to-object mapping with conventions
+- **[Pebble](docs/pebble.md)** — Lightweight immutable snapshots with fingerprinting
+- **[Advanced Usage](docs/advanced_usage.md)** — Patterns for complex applications
+- **[API Reference](docs/api_reference.md)** — Complete API documentation
 
 ### Guides
 
-- **[Migration Guide](docs/migration_guide.md)** - Migrate from arrays, stdClass, Doctrine, Laravel
-- **[Troubleshooting](docs/troubleshooting.md)** - Common issues and solutions
-
-## 🎯 Use Cases
-
-### API Development
-
-```php
-// Request validation
-final readonly class CreateUserRequest extends Granite
-{
-    public function __construct(
-        #[Required]
-        #[StringType]
-        #[Min(2)]
-        public string $name,
-        
-        #[Required]
-        #[Email]
-        public string $email,
-        
-        #[Required]
-        #[Min(8)]
-        #[Regex('/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/', 'Password must contain uppercase, lowercase, and number')]
-        public string $password
-    ) {}
-}
-
-// API Response
-final readonly class UserResponse extends Granite
-{
-    public function __construct(
-        public int $id,
-        public string $name,
-        public string $email,
-        
-        #[SerializedName('member_since')]
-        public DateTime $createdAt
-    ) {}
-    
-    public static function fromEntity(User $user): self
-    {
-        return new self(
-            id: $user->id,
-            name: $user->name,
-            email: $user->email,
-            createdAt: $user->createdAt
-        );
-    }
-}
-```
-
-### Domain Modeling
-
-```php
-// Value Objects
-final readonly class Money extends Granite
-{
-    public function __construct(
-        #[Required]
-        #[NumberType]
-        #[Min(0)]
-        public float $amount,
-        
-        #[Required]
-        #[StringType]
-        #[Min(3)]
-        #[Max(3)]
-        public string $currency
-    ) {}
-    
-    public function add(Money $other): Money
-    {
-        if ($this->currency !== $other->currency) {
-            throw new InvalidArgumentException('Cannot add different currencies');
-        }
-        
-        return new Money($this->amount + $other->amount, $this->currency);
-    }
-}
-
-// Aggregates
-final readonly class Order extends Granite
-{
-    public function __construct(
-        public ?int $id,
-        
-        #[Required]
-        public int $customerId,
-        
-        #[Required]
-        #[ArrayType]
-        #[Each(new Rules\Callback(fn($item) => OrderItem::from($item)))]
-        public array $items,
-        
-        #[Required]
-        public OrderStatus $status = OrderStatus::PENDING
-    ) {}
-    
-    public function getTotal(): Money
-    {
-        $total = new Money(0.0, 'USD');
-        foreach ($this->items as $item) {
-            $total = $total->add($item->getTotal());
-        }
-        return $total;
-    }
-}
-```
-
-### Object Mapping with ObjectMapper
-
-```php
-use Ninja\Granite\Mapping\ObjectMapper;
-use Ninja\Granite\Mapping\ObjectMapperConfig;
-use Ninja\Granite\Mapping\Attributes\MapFrom;
-
-// Source entity
-final readonly class UserEntity extends Granite
-{
-    public function __construct(
-        public int $userId,
-        public string $fullName,
-        public string $emailAddress,
-        public DateTime $createdAt
-    ) {}
-}
-
-// Destination DTO with mapping attributes
-final readonly class UserSummary extends Granite
-{
-    public function __construct(
-        #[MapFrom('userId')]
-        public int $id,
-        
-        #[MapFrom('fullName')]
-        public string $name,
-        
-        #[MapFrom('emailAddress')]
-        public string $email
-    ) {}
-}
-
-// Create ObjectMapper with clean configuration
-$mapper = new ObjectMapper(
-    ObjectMapperConfig::forProduction()
-        ->withConventions(true, 0.8)
-        ->withSharedCache()
-);
-
-// Automatic mapping
-$summary = $mapper->map($userEntity, UserSummary::class);
-```
-
-## 🔥 Advanced Features
-
-### Convention-Based Mapping
-
-```php
-// Automatically maps between different naming conventions
-class SourceClass {
-    public string $firstName;     // camelCase
-    public string $email_address; // snake_case
-    public string $UserID;        // PascalCase
-}
-
-class DestinationClass {
-    public string $first_name;    // snake_case
-    public string $emailAddress;  // camelCase  
-    public string $user_id;       // snake_case
-}
-
-$mapper = new ObjectMapper(
-    ObjectMapperConfig::create()
-        ->withConventions(true, 0.8)
-);
-
-$result = $mapper->map($source, DestinationClass::class);
-// Properties automatically mapped based on naming conventions!
-```
-
-### Advanced ObjectMapper Configuration
-
-```php
-use Ninja\Granite\Mapping\ObjectMapperConfig;
-use Ninja\Granite\Mapping\MappingProfile;
-
-// Fluent configuration with builder pattern
-$mapper = new ObjectMapper(
-    ObjectMapperConfig::forProduction()
-        ->withSharedCache()
-        ->withConventions(true, 0.8)
-        ->withProfile(new UserMappingProfile())
-        ->withProfile(new ProductMappingProfile())
-        ->withWarmup()
-);
-
-// Predefined configurations
-$devMapper = new ObjectMapper(ObjectMapperConfig::forDevelopment());
-$prodMapper = new ObjectMapper(ObjectMapperConfig::forProduction());
-$testMapper = new ObjectMapper(ObjectMapperConfig::forTesting());
-```
-
-### Custom Mapping Profiles
-
-```php
-use Ninja\Granite\Mapping\MappingProfile;
-
-class UserMappingProfile extends MappingProfile
-{
-    protected function configure(): void
-    {
-        // Complex transformations
-        $this->createMap(UserEntity::class, UserResponse::class)
-            ->forMember('fullName', fn($m) => 
-                $m->using(function($value, $sourceData) {
-                    return $sourceData['firstName'] . ' ' . $sourceData['lastName'];
-                })
-            )
-            ->forMember('age', fn($m) => 
-                $m->mapFrom('birthDate')
-                  ->using(fn($birthDate) => (new DateTime())->diff($birthDate)->y)
-            )
-            ->forMember('isActive', fn($m) => 
-                $m->mapFrom('status')
-                  ->using(fn($status) => $status === 'active')
-            )
-            ->seal();
-
-        // Bidirectional mapping
-        $this->createMapBidirectional(UserEntity::class, UserDto::class)
-            ->forMembers('userId', 'id')
-            ->forMembers('fullName', 'name')
-            ->forMembers('emailAddress', 'email')
-            ->seal();
-    }
-}
-```
-
-### Complex Validation
-
-```php
-final readonly class CreditCard extends Granite
-{
-    public function __construct(
-        #[Required]
-        #[Regex('/^\d{4}\s?\d{4}\s?\d{4}\s?\d{4}$/', 'Invalid card number format')]
-        public string $number,
-        
-        #[Required]
-        #[Regex('/^(0[1-9]|1[0-2])\/([0-9]{2})$/', 'Invalid expiry format (MM/YY)')]
-        public string $expiry,
-        
-        #[Required]
-        #[Regex('/^\d{3,4}$/', 'Invalid CVV')]
-        public string $cvv,
-        
-        #[When(
-            condition: fn($value, $data) => $data['type'] === 'business',
-            rule: new Required()
-        )]
-        public ?string $companyName = null
-    ) {}
-    
-    protected static function rules(): array
-    {
-        return [
-            'number' => [
-                new Callback(function($number) {
-                    // Luhn algorithm validation
-                    return $this->isValidLuhn(str_replace(' ', '', $number));
-                }, 'Invalid credit card number')
-            ]
-        ];
-    }
-}
-```
-
-### Global ObjectMapper Configuration
-
-```php
-// Configure once at application startup
-ObjectMapper::configure(function(ObjectMapperConfig $config) {
-    $config->withSharedCache()
-           ->withConventions(true, 0.8)
-           ->withProfiles([
-               new UserMappingProfile(),
-               new ProductMappingProfile(),
-               new OrderMappingProfile()
-           ])
-           ->withWarmup();
-});
-
-// Use anywhere in your application
-$mapper = ObjectMapper::getInstance();
-$userDto = $mapper->map($userEntity, UserDto::class);
-```
-
-## 🛠 Validation Rules
-
-### Built-in Rules
-
-| Rule | Description | Example |
-|------|-------------|---------|
-| `#[Required]` | Field must not be null | `#[Required('Name is required')]` |
-| `#[Email]` | Valid email format | `#[Email('Invalid email')]` |
-| `#[Min(5)]` | Minimum length/value | `#[Min(5, 'Too short')]` |
-| `#[Max(100)]` | Maximum length/value | `#[Max(100, 'Too long')]` |
-| `#[Regex('/pattern/')]` | Regular expression | `#[Regex('/^\d+$/', 'Numbers only')]` |
-| `#[In(['a', 'b'])]` | Value in list | `#[In(['active', 'inactive'])]` |
-| `#[Url]` | Valid URL format | `#[Url('Invalid URL')]` |
-| `#[IpAddress]` | Valid IP address | `#[IpAddress('Invalid IP')]` |
-| `#[StringType]` | Must be string | `#[StringType]` |
-| `#[IntegerType]` | Must be integer | `#[IntegerType]` |
-| `#[NumberType]` | Must be number | `#[NumberType]` |
-| `#[BooleanType]` | Must be boolean | `#[BooleanType]` |
-| `#[ArrayType]` | Must be array | `#[ArrayType]` |
-| `#[EnumType]` | Valid enum value | `#[EnumType(Status::class)]` |
-| `#[Each(...)]` | Validate array items | `#[Each(new Email())]` |
-| `#[When(...)]` | Conditional validation | `#[When($condition, $rule)]` |
-
-### 📅 Carbon Date Validation Rules
-
-| Rule | Description | Example |
-|------|-------------|---------|
-| `#[Age(min: 18, max: 65)]` | Validate age range | `#[Age(min: 18, message: 'Must be adult')]` |
-| `#[BusinessDay]` | Must be a business day | `#[BusinessDay('Only weekdays allowed')]` |
-| `#[Future]` | Date must be in the future | `#[Future('Event must be upcoming')]` |
-| `#[Past]` | Date must be in the past | `#[Past('Birth date must be past')]` |
-| `#[Range(min: 'now', max: '+1 year')]` | Date within range | `#[Range(min: 'today', max: 'next month')]` |
-| `#[Weekend]` | Must be weekend | `#[Weekend('Event only on weekends')]` |
+- **[Migration Guide](docs/migration_guide.md)** — Migrate from arrays, stdClass, Doctrine, Laravel
+- **[Troubleshooting](docs/troubleshooting.md)** — Common issues and solutions
 
 ## 📈 Performance & Benchmarks
 
@@ -799,82 +189,26 @@ Classes that don't qualify for the fast path (those with validation attributes, 
 php benchmarks/GraniteBench.php
 ```
 
-## 🧪 Testing
-
-Granite objects are perfect for testing due to their immutability and validation:
-
-```php
-class UserTest extends PHPUnit\Framework\TestCase
-{
-    public function testUserCreation(): void
-    {
-        $user = User::from([
-            'name' => 'John Doe',
-            'email' => 'john@example.com'
-        ]);
-        
-        $this->assertEquals('John Doe', $user->name);
-        $this->assertEquals('john@example.com', $user->email);
-    }
-    
-    public function testObjectMapping(): void
-    {
-        $mapper = new ObjectMapper(ObjectMapperConfig::forTesting());
-        
-        $entity = new UserEntity(1, 'John Doe', 'john@example.com', new DateTime());
-        $dto = $mapper->map($entity, UserDto::class);
-        
-        $this->assertInstanceOf(UserDto::class, $dto);
-        $this->assertEquals(1, $dto->id);
-    }
-    
-    public function testImmutability(): void
-    {
-        $user = User::from(['name' => 'John', 'email' => 'john@example.com']);
-        $updated = $user->with(['name' => 'Jane']);
-        
-        // Original unchanged
-        $this->assertEquals('John', $user->name);
-        // New instance created
-        $this->assertEquals('Jane', $updated->name);
-    }
-}
-```
-
 ## ⚠️ Deprecation Notice
 
-**Important:** As of version 2.0.0, `GraniteDTO` and `GraniteVO` are **deprecated** in favor of the unified `Granite` base class.
+`GraniteDTO` and `GraniteVO` are deprecated since v2.0.0 in favor of the unified `Granite` base class. Both still extend `Granite` for backward compatibility but will be removed in v3.0.0.
 
-- ❌ **Deprecated:** `Ninja\Granite\GraniteDTO` (will be removed in v3.0.0)
-- ❌ **Deprecated:** `Ninja\Granite\GraniteVO` (will be removed in v3.0.0)
-- ✅ **Use instead:** `Ninja\Granite\Granite`
-
-**Migration:**
 ```php
-// ❌ Old (deprecated)
+// ❌ Deprecated — use Granite instead
 final readonly class User extends GraniteVO { }
-final readonly class UserDTO extends GraniteDTO { }
-
-// ✅ New (recommended)
+// ✅
 final readonly class User extends Granite { }
 ```
 
-Both deprecated classes currently extend `Granite` for backward compatibility, so your existing code will continue to work. However, please migrate to `Granite` before version 3.0.0.
-
 ## 🔧 Requirements
 
-- **PHP 8.3+** - Takes advantage of modern PHP features
-- **No dependencies** - Zero external dependencies for maximum compatibility
+- **PHP 8.3+** — Takes advantage of modern PHP features
+- **No dependencies** — Zero external dependencies for maximum compatibility
 
-## 📦 Installation & Setup
+## 📦 Installation
 
 ```bash
-# Install via Composer
 composer require diego-ninja/granite
-
-# Optional: Configure cache directory for persistent mapping cache
-mkdir cache/granite
-chmod 755 cache/granite
 ```
 
 ## 🤝 Contributing

--- a/README.md
+++ b/README.md
@@ -107,9 +107,10 @@ This documentation has been generated almost in its entirety using 🦠 Claude 4
 - Efficient array comparison without JSON encoding
 
 ### ⚡ **Performance Optimized**
-- Reflection caching for improved performance
-- Memory-efficient object creation
-- Lazy loading support
+- Fast path bypasses hydration pipeline for simple DTOs (~3.5x vs plain PHP)
+- WeakMap caching for `array()` and `json()` (near-native speed on repeated calls)
+- Reflection caching and O(1) hidden property lookups
+- Direct property access for serialization and comparison
 
 ## 🚀 Quick Start
 
@@ -714,31 +715,88 @@ $userDto = $mapper->map($userEntity, UserDto::class);
 | `#[Range(min: 'now', max: '+1 year')]` | Date within range | `#[Range(min: 'today', max: 'next month')]` |
 | `#[Weekend]` | Must be weekend | `#[Weekend('Event only on weekends')]` |
 
-## 📈 Performance
+## 📈 Performance & Benchmarks
 
-Granite is optimized for performance with:
+Granite uses a **multi-layer fast path** system that detects simple DTOs at class-load time and bypasses the full hydration pipeline (reflection, metadata, type conversion) entirely. For objects that qualify, the overhead vs plain PHP constructors is minimal.
 
-- **Reflection caching** - Class metadata cached automatically
-- **Mapping cache** - ObjectMapper configurations cached
-- **Memory efficiency** - Immutable objects reduce memory overhead
-- **Lazy loading** - Load related data only when needed
-- **Specialized components** - Refactored architecture with focused responsibilities
+### Benchmark Results
 
-```php
-// Use shared cache for web applications
-$mapper = new ObjectMapper(
-    ObjectMapperConfig::forProduction()
-        ->withSharedCache()
-        ->withWarmup()  // Preload configurations
-);
+Benchmarked on PHP 8.4, comparing Granite against plain PHP constructors and `Pebble` (Granite's lightweight companion). The test DTO has 6 fields (`int`, `string`, `string`, `int`, `string`, `bool`).
 
-// Preload mappings for better performance
-use Ninja\Granite\Mapping\MappingPreloader;
+#### Object Creation
 
-MappingPreloader::preload($mapper, [
-    [UserEntity::class, UserResponse::class],
-    [ProductEntity::class, ProductResponse::class]
-]);
+| Benchmark | µs/op | vs Plain PHP |
+|-----------|------:|:------------:|
+| Plain PHP constructor | 0.33 | — |
+| `Granite::from(array)` | 1.14 | 3.5x |
+| `Granite::from(named args)` | 1.13 | 3.4x |
+| `Pebble::from(array)` | 3.62 | 11.1x |
+
+#### Nested Object Creation (3 objects)
+
+| Benchmark | µs/op | vs Plain PHP |
+|-----------|------:|:------------:|
+| Plain PHP constructors | 0.78 | — |
+| `Granite::from(array)` | 3.63 | 4.6x |
+| `Pebble::from(array)` | 6.80 | 8.7x |
+
+Granite recursively applies the fast path to nested Granite-typed properties, so the overhead scales linearly with object depth rather than exploding through the full hydration pipeline.
+
+#### Serialization
+
+| Benchmark | µs/op | vs Plain PHP |
+|-----------|------:|:------------:|
+| Plain PHP `toArray()` | 0.19 | — |
+| `Granite array()` | 0.25 | 1.3x |
+| Plain PHP `json_encode(array)` | 0.25 | — |
+| `Granite json()` | 0.26 | 1.0x |
+
+Both `array()` and `json()` results are cached in a `WeakMap`. Since Granite objects are readonly, the serialized representation never changes, so repeated calls return instantly. The `json()` method effectively matches native `json_encode` performance.
+
+#### Equality Check
+
+| Benchmark | µs/op | vs Plain PHP |
+|-----------|------:|:------------:|
+| Plain array `===` | 0.12 | — |
+| `Granite equals()` | 0.48 | 4.0x |
+| `Pebble equals()` (fingerprint) | 0.31 | 2.6x |
+
+For simple DTOs, `equals()` compares properties directly without building intermediate arrays, with early exit on the first difference.
+
+#### Collection (100 items, create from array)
+
+| Benchmark | µs/op | vs Plain PHP |
+|-----------|------:|:------------:|
+| Plain PHP `array_map` + constructors | 31 | — |
+| Granite `array_map` + `from()` | 106 | 3.4x |
+| Pebble `array_map` + `from()` | 343 | 11.1x |
+
+#### Property Access
+
+Granite uses native PHP readonly promoted properties — property access is **identical** to plain PHP objects, with zero overhead:
+
+| Benchmark | µs/op |
+|-----------|------:|
+| Plain PHP readonly | 0.15 |
+| Granite readonly | 0.14 |
+| Pebble `__get()` | 1.03 |
+
+### How it works
+
+Granite's performance comes from three layers of optimization:
+
+1. **Fast path detection** (`ClassProfile`) — At class-load time, Granite analyzes each class and determines if it can skip the full hydration pipeline. A class qualifies when all constructor parameters are either primitive types (`int`, `string`, `float`, `bool`, `array`) or other Granite subclasses, and the class has no special attributes (`#[Hidden]`, `#[SerializedName]`, validation rules, etc.).
+
+2. **WeakMap caching** — `array()` and `json()` results are cached in a `WeakMap` keyed by object instance. Since Granite objects are readonly, the cache is always valid. When the object is garbage collected, the cache entry is automatically cleaned up.
+
+3. **Direct property access** — For serialization and comparison, Granite reads properties directly by name (`$instance->$name`) instead of going through reflection, metadata lookups, and type conversion.
+
+Classes that don't qualify for the fast path (those with validation attributes, naming conventions, Carbon dates, etc.) use the standard hydration pipeline, which is still optimized with reflection caching and O(1) hidden property lookups.
+
+### Running the Benchmarks
+
+```bash
+php benchmarks/GraniteBench.php
 ```
 
 ## 🧪 Testing

--- a/src/Serialization/Metadata.php
+++ b/src/Serialization/Metadata.php
@@ -4,7 +4,12 @@ namespace Ninja\Granite\Serialization;
 
 class Metadata
 {
-    public function __construct(private array $propertyNames = [], private array $hiddenProperties = []) {}
+    private array $hiddenProperties;
+
+    public function __construct(private array $propertyNames = [], array $hiddenProperties = [])
+    {
+        $this->hiddenProperties = empty($hiddenProperties) ? [] : array_fill_keys($hiddenProperties, true);
+    }
 
     public function getSerializedName(string $propertyName): string
     {
@@ -14,7 +19,7 @@ class Metadata
 
     public function isHidden(string $propertyName): bool
     {
-        return in_array($propertyName, $this->hiddenProperties, true);
+        return isset($this->hiddenProperties[$propertyName]);
     }
 
     public function mapPropertyName(string $propertyName, string $serializedName): self
@@ -25,18 +30,15 @@ class Metadata
 
     public function hideProperty(string $propertyName): self
     {
-        if ( ! in_array($propertyName, $this->hiddenProperties, true)) {
-            $this->hiddenProperties[] = $propertyName;
-        }
+        $this->hiddenProperties[$propertyName] = true;
         return $this;
     }
 
-    // Método para depuración que puede ayudar a verificar el estado
     public function debug(): array
     {
         return [
             'propertyNames' => $this->propertyNames,
-            'hiddenProperties' => $this->hiddenProperties,
+            'hiddenProperties' => array_keys($this->hiddenProperties),
         ];
     }
 }

--- a/src/Serialization/MetadataCache.php
+++ b/src/Serialization/MetadataCache.php
@@ -234,7 +234,6 @@ class MetadataCache
     {
         try {
             $reflectionMethod = new ReflectionMethod($class, $methodName);
-            $reflectionMethod->setAccessible(true);
             return $reflectionMethod->invoke(null);
         } catch (ReflectionException $e) {
             throw new \Ninja\Granite\Exceptions\ReflectionException($class, $methodName, $e->getMessage());

--- a/src/Serialization/SerializationCache.php
+++ b/src/Serialization/SerializationCache.php
@@ -1,6 +1,6 @@
 <?php
 
-// ABOUTME: WeakMap-based cache for serialized array results.
+// ABOUTME: WeakMap-based cache for serialized array and JSON results.
 // ABOUTME: Auto-cleans via GC since Granite objects are readonly/immutable.
 
 namespace Ninja\Granite\Serialization;
@@ -10,20 +10,38 @@ use WeakMap;
 final class SerializationCache
 {
     /** @var WeakMap<object, array> */
-    private static ?WeakMap $cache = null;
+    private static ?WeakMap $arrayCache = null;
+
+    /** @var WeakMap<object, string> */
+    private static ?WeakMap $jsonCache = null;
 
     public static function get(object $instance): ?array
     {
-        if (null === self::$cache) {
+        if (null === self::$arrayCache) {
             return null;
         }
 
-        return self::$cache[$instance] ?? null;
+        return self::$arrayCache[$instance] ?? null;
     }
 
     public static function set(object $instance, array $result): void
     {
-        self::$cache ??= new WeakMap();
-        self::$cache[$instance] = $result;
+        self::$arrayCache ??= new WeakMap();
+        self::$arrayCache[$instance] = $result;
+    }
+
+    public static function getJson(object $instance): ?string
+    {
+        if (null === self::$jsonCache) {
+            return null;
+        }
+
+        return self::$jsonCache[$instance] ?? null;
+    }
+
+    public static function setJson(object $instance, string $result): void
+    {
+        self::$jsonCache ??= new WeakMap();
+        self::$jsonCache[$instance] = $result;
     }
 }

--- a/src/Serialization/SerializationCache.php
+++ b/src/Serialization/SerializationCache.php
@@ -1,0 +1,29 @@
+<?php
+
+// ABOUTME: WeakMap-based cache for serialized array results.
+// ABOUTME: Auto-cleans via GC since Granite objects are readonly/immutable.
+
+namespace Ninja\Granite\Serialization;
+
+use WeakMap;
+
+final class SerializationCache
+{
+    /** @var WeakMap<object, array> */
+    private static ?WeakMap $cache = null;
+
+    public static function get(object $instance): ?array
+    {
+        if (null === self::$cache) {
+            return null;
+        }
+
+        return self::$cache[$instance] ?? null;
+    }
+
+    public static function set(object $instance, array $result): void
+    {
+        self::$cache ??= new WeakMap();
+        self::$cache[$instance] = $result;
+    }
+}

--- a/src/Support/ClassProfile.php
+++ b/src/Support/ClassProfile.php
@@ -1,10 +1,11 @@
 <?php
 
 // ABOUTME: Pre-computed class metadata for fast-path object creation.
-// ABOUTME: Detects simple DTOs (primitive types, no attributes) to bypass the hydration pipeline.
+// ABOUTME: Detects simple DTOs (primitive or Granite types, no attributes) to bypass the hydration pipeline.
 
 namespace Ninja\Granite\Support;
 
+use Ninja\Granite\Contracts\GraniteObject;
 use Ninja\Granite\Serialization\Attributes\DateTimeProvider;
 use Ninja\Granite\Serialization\Attributes\Hidden;
 use Ninja\Granite\Serialization\Attributes\SerializationConvention;
@@ -24,6 +25,9 @@ final class ClassProfile
 
     public readonly bool $canUseFastPath;
 
+    /** @var array<string, class-string> Param name => Granite subclass for non-primitive params */
+    public readonly array $graniteParams;
+
     /** @var class-string */
     private readonly string $className;
 
@@ -34,13 +38,15 @@ final class ClassProfile
      * @param class-string $className
      * @param array<string, mixed> $constructorParams
      * @param string[] $paramNames
+     * @param array<string, class-string> $graniteParams
      */
-    private function __construct(string $className, array $constructorParams, array $paramNames, bool $canUseFastPath)
+    private function __construct(string $className, array $constructorParams, array $paramNames, bool $canUseFastPath, array $graniteParams = [])
     {
         $this->className = $className;
         $this->constructorParams = $constructorParams;
         $this->paramNames = $paramNames;
         $this->canUseFastPath = $canUseFastPath;
+        $this->graniteParams = $graniteParams;
     }
 
     /**
@@ -52,16 +58,18 @@ final class ClassProfile
         $constructor = $reflection->getConstructor();
 
         if (null === $constructor) {
-            return new self($class, [], [], false);
+            return new self($class, [], [], false, []);
         }
 
         $params = [];
+        /** @var array<string, class-string> $graniteParams */
+        $graniteParams = [];
         $canUseFastPath = !self::hasDisqualifyingClassAttributes($reflection)
             && !self::hasOverriddenRules($reflection)
             && !self::hasReadonlyParentProperties($reflection);
 
         foreach ($constructor->getParameters() as $param) {
-            if ($canUseFastPath && !self::isSimpleParameter($param)) {
+            if ($canUseFastPath && !self::isFastPathParameter($param, $graniteParams)) {
                 $canUseFastPath = false;
             }
 
@@ -76,7 +84,11 @@ final class ClassProfile
             }
         }
 
-        return new self($class, $params, array_keys($params), $canUseFastPath);
+        if (!$canUseFastPath) {
+            $graniteParams = [];
+        }
+
+        return new self($class, $params, array_keys($params), $canUseFastPath, $graniteParams);
     }
 
     /**
@@ -96,11 +108,22 @@ final class ClassProfile
 
         $constructorArgs = [];
         foreach ($this->paramNames as $name) {
-            if (array_key_exists($name, $data)) {
-                $constructorArgs[] = $data[$name];
-            } else {
+            if (!array_key_exists($name, $data)) {
                 return null;
             }
+
+            $value = $data[$name];
+
+            if (isset($this->graniteParams[$name])) {
+                if (is_array($value)) {
+                    $graniteClass = $this->graniteParams[$name];
+                    $value = $graniteClass::from($value);
+                } elseif (null !== $value && !$value instanceof GraniteObject) {
+                    return null;
+                }
+            }
+
+            $constructorArgs[] = $value;
         }
 
         $className = $this->className;
@@ -108,25 +131,33 @@ final class ClassProfile
         return new $className(...$constructorArgs);
     }
 
-    private static function isSimpleParameter(ReflectionParameter $param): bool
+    /**
+     * Check if a parameter type is compatible with the fast path.
+     * Returns true for builtin types and Granite subclasses.
+     * For Granite subclasses, the class name is added to $graniteParams.
+     *
+     * @param array<string, class-string> $graniteParams Collects Granite-typed param names
+     */
+    private static function isFastPathParameter(ReflectionParameter $param, array &$graniteParams): bool
     {
         $type = $param->getType();
 
-        if (null === $type) {
-            return false;
-        }
-
-        if (!$type instanceof ReflectionNamedType) {
+        if (null === $type || !$type instanceof ReflectionNamedType) {
             return false;
         }
 
         $typeName = $type->getName();
 
-        if (!in_array($typeName, self::BUILTIN_TYPES, true)) {
-            return false;
+        if (in_array($typeName, self::BUILTIN_TYPES, true)) {
+            return true;
         }
 
-        return true;
+        if (is_subclass_of($typeName, GraniteObject::class)) {
+            $graniteParams[$param->getName()] = $typeName;
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/Support/ClassProfile.php
+++ b/src/Support/ClassProfile.php
@@ -84,6 +84,14 @@ final class ClassProfile
             }
         }
 
+        // Ensure all public properties are covered by constructor params
+        if ($canUseFastPath) {
+            $publicProps = $reflection->getProperties(\ReflectionProperty::IS_PUBLIC);
+            if (count($publicProps) !== count($params)) {
+                $canUseFastPath = false;
+            }
+        }
+
         if (!$canUseFastPath) {
             $graniteParams = [];
         }
@@ -129,6 +137,31 @@ final class ClassProfile
         $className = $this->className;
 
         return new $className(...$constructorArgs);
+    }
+
+    /**
+     * Build array representation by direct property access, bypassing reflection and metadata.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $instance): array
+    {
+        $result = [];
+        foreach ($this->paramNames as $name) {
+            try {
+                $value = $instance->$name;
+            } catch (\Error) {
+                continue;
+            }
+
+            if (isset($this->graniteParams[$name]) && $value instanceof GraniteObject) {
+                $value = $value->array();
+            }
+
+            $result[$name] = $value;
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Support/ClassProfile.php
+++ b/src/Support/ClassProfile.php
@@ -6,6 +6,7 @@
 namespace Ninja\Granite\Support;
 
 use Ninja\Granite\Contracts\GraniteObject;
+use Ninja\Granite\Granite;
 use Ninja\Granite\Serialization\Attributes\DateTimeProvider;
 use Ninja\Granite\Serialization\Attributes\Hidden;
 use Ninja\Granite\Serialization\Attributes\SerializationConvention;
@@ -148,6 +149,37 @@ final class ClassProfile
         }
 
         return new $className(...$constructorArgs);
+    }
+
+    /**
+     * Compare two instances by direct property access, with early exit on first difference.
+     */
+    public function areEqual(object $a, object $b): bool
+    {
+        if (empty($this->graniteParams)) {
+            foreach ($this->paramNames as $name) {
+                if ($a->$name !== $b->$name) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        foreach ($this->paramNames as $name) {
+            $va = $a->$name;
+            $vb = $b->$name;
+
+            if ($va instanceof Granite && $vb instanceof Granite) {
+                if (!$va->equals($vb)) {
+                    return false;
+                }
+            } elseif ($va !== $vb) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Support/ClassProfile.php
+++ b/src/Support/ClassProfile.php
@@ -5,17 +5,21 @@
 
 namespace Ninja\Granite\Support;
 
+use Error;
 use Ninja\Granite\Contracts\GraniteObject;
 use Ninja\Granite\Granite;
+use Ninja\Granite\Serialization\Attributes\CarbonDate;
 use Ninja\Granite\Serialization\Attributes\DateTimeProvider;
 use Ninja\Granite\Serialization\Attributes\Hidden;
 use Ninja\Granite\Serialization\Attributes\SerializationConvention;
 use Ninja\Granite\Serialization\Attributes\SerializedName;
-use Ninja\Granite\Serialization\Attributes\CarbonDate;
 use ReflectionAttribute;
 use ReflectionClass;
+use ReflectionException;
 use ReflectionNamedType;
 use ReflectionParameter;
+use ReflectionProperty;
+use stdClass;
 
 final class ClassProfile
 {
@@ -65,12 +69,12 @@ final class ClassProfile
         $params = [];
         /** @var array<string, class-string> $graniteParams */
         $graniteParams = [];
-        $canUseFastPath = !self::hasDisqualifyingClassAttributes($reflection)
-            && !self::hasOverriddenRules($reflection)
-            && !self::hasReadonlyParentProperties($reflection);
+        $canUseFastPath = ! self::hasDisqualifyingClassAttributes($reflection)
+            && ! self::hasOverriddenRules($reflection)
+            && ! self::hasReadonlyParentProperties($reflection);
 
         foreach ($constructor->getParameters() as $param) {
-            if ($canUseFastPath && !self::isFastPathParameter($param, $graniteParams)) {
+            if ($canUseFastPath && ! self::isFastPathParameter($param, $graniteParams)) {
                 $canUseFastPath = false;
             }
 
@@ -87,13 +91,13 @@ final class ClassProfile
 
         // Ensure all public properties are covered by constructor params
         if ($canUseFastPath) {
-            $publicProps = $reflection->getProperties(\ReflectionProperty::IS_PUBLIC);
+            $publicProps = $reflection->getProperties(ReflectionProperty::IS_PUBLIC);
             if (count($publicProps) !== count($params)) {
                 $canUseFastPath = false;
             }
         }
 
-        if (!$canUseFastPath) {
+        if ( ! $canUseFastPath) {
             $graniteParams = [];
         }
 
@@ -130,7 +134,7 @@ final class ClassProfile
         // DTOs with Granite-typed params: need per-param conversion
         $constructorArgs = [];
         foreach ($this->paramNames as $name) {
-            if (!array_key_exists($name, $data)) {
+            if ( ! array_key_exists($name, $data)) {
                 return null;
             }
 
@@ -140,7 +144,7 @@ final class ClassProfile
                 if (is_array($value)) {
                     $graniteClass = $this->graniteParams[$name];
                     $value = $graniteClass::from($value);
-                } elseif (null !== $value && !$value instanceof GraniteObject) {
+                } elseif (null !== $value && ! $value instanceof GraniteObject) {
                     return null;
                 }
             }
@@ -158,7 +162,7 @@ final class ClassProfile
     {
         if (empty($this->graniteParams)) {
             foreach ($this->paramNames as $name) {
-                if ($a->$name !== $b->$name) {
+                if ($a->{$name} !== $b->{$name}) {
                     return false;
                 }
             }
@@ -167,11 +171,11 @@ final class ClassProfile
         }
 
         foreach ($this->paramNames as $name) {
-            $va = $a->$name;
-            $vb = $b->$name;
+            $va = $a->{$name};
+            $vb = $b->{$name};
 
             if ($va instanceof Granite && $vb instanceof Granite) {
-                if (!$va->equals($vb)) {
+                if ( ! $va->equals($vb)) {
                     return false;
                 }
             } elseif ($va !== $vb) {
@@ -192,8 +196,8 @@ final class ClassProfile
         $result = [];
         foreach ($this->paramNames as $name) {
             try {
-                $value = $instance->$name;
-            } catch (\Error) {
+                $value = $instance->{$name};
+            } catch (Error) {
                 continue;
             }
 
@@ -218,7 +222,7 @@ final class ClassProfile
     {
         $type = $param->getType();
 
-        if (null === $type || !$type instanceof ReflectionNamedType) {
+        if (null === $type || ! $type instanceof ReflectionNamedType) {
             return false;
         }
 
@@ -247,7 +251,7 @@ final class ClassProfile
         ];
 
         foreach ($disqualifying as $attrClass) {
-            if (!empty($reflection->getAttributes($attrClass, ReflectionAttribute::IS_INSTANCEOF))) {
+            if ( ! empty($reflection->getAttributes($attrClass, ReflectionAttribute::IS_INSTANCEOF))) {
                 return true;
             }
         }
@@ -263,7 +267,7 @@ final class ClassProfile
         $property = null;
         try {
             $property = $reflection->getProperty($propertyName);
-        } catch (\ReflectionException) {
+        } catch (ReflectionException) {
             return false;
         }
 
@@ -301,7 +305,7 @@ final class ClassProfile
             // rules() is defined in HasValidation trait, used by Granite.
             // If declaring class matches the concrete class, it's overridden.
             return $declaringClass === $reflection->getName();
-        } catch (\ReflectionException) {
+        } catch (ReflectionException) {
             return false;
         }
     }
@@ -311,7 +315,7 @@ final class ClassProfile
      */
     private static function hasReadonlyParentProperties(ReflectionClass $reflection): bool
     {
-        $properties = $reflection->getProperties(\ReflectionProperty::IS_PUBLIC);
+        $properties = $reflection->getProperties(ReflectionProperty::IS_PUBLIC);
         foreach ($properties as $property) {
             if ($property->isReadOnly() && $property->getDeclaringClass()->getName() !== $reflection->getName()) {
                 return true;
@@ -321,11 +325,11 @@ final class ClassProfile
         return false;
     }
 
-    private static function required(): \stdClass
+    private static function required(): stdClass
     {
-        /** @var \stdClass|null $sentinel */
+        /** @var stdClass|null $sentinel */
         static $sentinel = null;
-        $sentinel ??= new \stdClass();
+        $sentinel ??= new stdClass();
 
         return $sentinel;
     }

--- a/src/Support/ClassProfile.php
+++ b/src/Support/ClassProfile.php
@@ -24,17 +24,22 @@ final class ClassProfile
 
     public readonly bool $canUseFastPath;
 
-    /** @var ReflectionClass<object> */
-    private readonly ReflectionClass $reflectionClass;
+    /** @var class-string */
+    private readonly string $className;
+
+    /** @var string[] Param names in constructor order */
+    private readonly array $paramNames;
 
     /**
-     * @param ReflectionClass<object> $reflectionClass
+     * @param class-string $className
      * @param array<string, mixed> $constructorParams
+     * @param string[] $paramNames
      */
-    private function __construct(ReflectionClass $reflectionClass, array $constructorParams, bool $canUseFastPath)
+    private function __construct(string $className, array $constructorParams, array $paramNames, bool $canUseFastPath)
     {
-        $this->reflectionClass = $reflectionClass;
+        $this->className = $className;
         $this->constructorParams = $constructorParams;
+        $this->paramNames = $paramNames;
         $this->canUseFastPath = $canUseFastPath;
     }
 
@@ -47,7 +52,7 @@ final class ClassProfile
         $constructor = $reflection->getConstructor();
 
         if (null === $constructor) {
-            return new self($reflection, [], false);
+            return new self($class, [], [], false);
         }
 
         $params = [];
@@ -71,7 +76,7 @@ final class ClassProfile
             }
         }
 
-        return new self($reflection, $params, $canUseFastPath);
+        return new self($class, $params, array_keys($params), $canUseFastPath);
     }
 
     /**
@@ -79,18 +84,18 @@ final class ClassProfile
      */
     public function tryFastPath(array $args): ?object
     {
-        $hasStringKeys = !empty(array_filter(array_keys($args), 'is_string'));
-
-        if ($hasStringKeys) {
-            $data = $args;
-        } elseif (1 === count($args) && is_array($args[0])) {
-            $data = $args[0];
+        if (array_is_list($args)) {
+            if (1 === count($args) && is_array($args[0])) {
+                $data = $args[0];
+            } else {
+                return null;
+            }
         } else {
-            return null;
+            $data = $args;
         }
 
         $constructorArgs = [];
-        foreach ($this->constructorParams as $name => $_) {
+        foreach ($this->paramNames as $name) {
             if (array_key_exists($name, $data)) {
                 $constructorArgs[] = $data[$name];
             } else {
@@ -98,7 +103,9 @@ final class ClassProfile
             }
         }
 
-        return $this->reflectionClass->newInstanceArgs($constructorArgs);
+        $className = $this->className;
+
+        return new $className(...$constructorArgs);
     }
 
     private static function isSimpleParameter(ReflectionParameter $param): bool

--- a/src/Support/ClassProfile.php
+++ b/src/Support/ClassProfile.php
@@ -1,0 +1,218 @@
+<?php
+
+// ABOUTME: Pre-computed class metadata for fast-path object creation.
+// ABOUTME: Detects simple DTOs (primitive types, no attributes) to bypass the hydration pipeline.
+
+namespace Ninja\Granite\Support;
+
+use Ninja\Granite\Serialization\Attributes\DateTimeProvider;
+use Ninja\Granite\Serialization\Attributes\Hidden;
+use Ninja\Granite\Serialization\Attributes\SerializationConvention;
+use Ninja\Granite\Serialization\Attributes\SerializedName;
+use Ninja\Granite\Serialization\Attributes\CarbonDate;
+use ReflectionAttribute;
+use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionParameter;
+
+final class ClassProfile
+{
+    private const array BUILTIN_TYPES = ['int', 'string', 'float', 'bool', 'array', 'null'];
+
+    /** @var array<string, mixed> Ordered map of param name => default value or REQUIRED sentinel */
+    public readonly array $constructorParams;
+
+    public readonly bool $canUseFastPath;
+
+    /** @var ReflectionClass<object> */
+    private readonly ReflectionClass $reflectionClass;
+
+    /**
+     * @param ReflectionClass<object> $reflectionClass
+     * @param array<string, mixed> $constructorParams
+     */
+    private function __construct(ReflectionClass $reflectionClass, array $constructorParams, bool $canUseFastPath)
+    {
+        $this->reflectionClass = $reflectionClass;
+        $this->constructorParams = $constructorParams;
+        $this->canUseFastPath = $canUseFastPath;
+    }
+
+    /**
+     * @param class-string $class
+     */
+    public static function build(string $class): self
+    {
+        $reflection = ReflectionCache::getClass($class);
+        $constructor = $reflection->getConstructor();
+
+        if (null === $constructor) {
+            return new self($reflection, [], false);
+        }
+
+        $params = [];
+        $canUseFastPath = !self::hasDisqualifyingClassAttributes($reflection)
+            && !self::hasOverriddenRules($reflection)
+            && !self::hasReadonlyParentProperties($reflection);
+
+        foreach ($constructor->getParameters() as $param) {
+            if ($canUseFastPath && !self::isSimpleParameter($param)) {
+                $canUseFastPath = false;
+            }
+
+            if ($canUseFastPath && self::hasDisqualifyingPropertyAttributes($reflection, $param->getName())) {
+                $canUseFastPath = false;
+            }
+
+            if ($param->isDefaultValueAvailable()) {
+                $params[$param->getName()] = $param->getDefaultValue();
+            } else {
+                $params[$param->getName()] = self::required();
+            }
+        }
+
+        return new self($reflection, $params, $canUseFastPath);
+    }
+
+    /**
+     * @return object|null Created instance, or null to fall back to slow path
+     */
+    public function tryFastPath(array $args): ?object
+    {
+        $hasStringKeys = !empty(array_filter(array_keys($args), 'is_string'));
+
+        if ($hasStringKeys) {
+            $data = $args;
+        } elseif (1 === count($args) && is_array($args[0])) {
+            $data = $args[0];
+        } else {
+            return null;
+        }
+
+        $constructorArgs = [];
+        foreach ($this->constructorParams as $name => $_) {
+            if (array_key_exists($name, $data)) {
+                $constructorArgs[] = $data[$name];
+            } else {
+                return null;
+            }
+        }
+
+        return $this->reflectionClass->newInstanceArgs($constructorArgs);
+    }
+
+    private static function isSimpleParameter(ReflectionParameter $param): bool
+    {
+        $type = $param->getType();
+
+        if (null === $type) {
+            return false;
+        }
+
+        if (!$type instanceof ReflectionNamedType) {
+            return false;
+        }
+
+        $typeName = $type->getName();
+
+        if (!in_array($typeName, self::BUILTIN_TYPES, true)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflection
+     */
+    private static function hasDisqualifyingClassAttributes(ReflectionClass $reflection): bool
+    {
+        $disqualifying = [
+            SerializationConvention::class,
+            DateTimeProvider::class,
+        ];
+
+        foreach ($disqualifying as $attrClass) {
+            if (!empty($reflection->getAttributes($attrClass, ReflectionAttribute::IS_INSTANCEOF))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflection
+     */
+    private static function hasDisqualifyingPropertyAttributes(ReflectionClass $reflection, string $propertyName): bool
+    {
+        $property = null;
+        try {
+            $property = $reflection->getProperty($propertyName);
+        } catch (\ReflectionException) {
+            return false;
+        }
+
+        $attributes = $property->getAttributes();
+        foreach ($attributes as $attr) {
+            $attrName = $attr->getName();
+            if (SerializedName::class === $attrName
+                || Hidden::class === $attrName
+                || is_subclass_of($attrName, \Ninja\Granite\Validation\Rules\AbstractRule::class)
+                || (class_exists(CarbonDate::class) && CarbonDate::class === $attrName)
+            ) {
+                return true;
+            }
+
+            // Check for validation attributes (any attribute that has asRule())
+            if (method_exists($attrName, 'asRule')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflection
+     */
+    private static function hasOverriddenRules(ReflectionClass $reflection): bool
+    {
+        try {
+            $rulesMethod = $reflection->getMethod('rules');
+            // If the declaring class is not Granite's HasValidation trait host,
+            // then the method has been overridden
+            $declaringClass = $rulesMethod->getDeclaringClass()->getName();
+
+            // rules() is defined in HasValidation trait, used by Granite.
+            // If declaring class matches the concrete class, it's overridden.
+            return $declaringClass === $reflection->getName();
+        } catch (\ReflectionException) {
+            return false;
+        }
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflection
+     */
+    private static function hasReadonlyParentProperties(ReflectionClass $reflection): bool
+    {
+        $properties = $reflection->getProperties(\ReflectionProperty::IS_PUBLIC);
+        foreach ($properties as $property) {
+            if ($property->isReadOnly() && $property->getDeclaringClass()->getName() !== $reflection->getName()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function required(): \stdClass
+    {
+        /** @var \stdClass|null $sentinel */
+        static $sentinel = null;
+        $sentinel ??= new \stdClass();
+
+        return $sentinel;
+    }
+}

--- a/src/Support/ClassProfile.php
+++ b/src/Support/ClassProfile.php
@@ -114,6 +114,19 @@ final class ClassProfile
             $data = $args;
         }
 
+        $className = $this->className;
+
+        // Pure-primitive DTOs: use C-level array_intersect_key + named args unpacking
+        if (empty($this->graniteParams)) {
+            $filtered = array_intersect_key($data, $this->constructorParams);
+            if (count($filtered) !== count($this->paramNames)) {
+                return null;
+            }
+
+            return new $className(...$filtered);
+        }
+
+        // DTOs with Granite-typed params: need per-param conversion
         $constructorArgs = [];
         foreach ($this->paramNames as $name) {
             if (!array_key_exists($name, $data)) {
@@ -133,8 +146,6 @@ final class ClassProfile
 
             $constructorArgs[] = $value;
         }
-
-        $className = $this->className;
 
         return new $className(...$constructorArgs);
     }

--- a/src/Support/ReflectionCache.php
+++ b/src/Support/ReflectionCache.php
@@ -26,6 +26,13 @@ final class ReflectionCache
     private static array $propertiesCache = [];
 
     /**
+     * Cache for class profiles.
+     *
+     * @var array<string, ClassProfile>
+     */
+    private static array $profileCache = [];
+
+    /**
      * Get a cached ReflectionClass instance.
      *
      * @param string $class Class name
@@ -64,5 +71,21 @@ final class ReflectionCache
         }
 
         return self::$propertiesCache[$class];
+    }
+
+    /**
+     * Get cached class profile for fast-path detection.
+     *
+     * @param class-string $class Class name
+     * @return ClassProfile Class profile
+     * @throws \Ninja\Granite\Exceptions\ReflectionException
+     */
+    public static function getClassProfile(string $class): ClassProfile
+    {
+        if ( ! isset(self::$profileCache[$class])) {
+            self::$profileCache[$class] = ClassProfile::build($class);
+        }
+
+        return self::$profileCache[$class];
     }
 }

--- a/src/Traits/HasComparison.php
+++ b/src/Traits/HasComparison.php
@@ -29,6 +29,13 @@ trait HasComparison
             return false;
         }
 
+        // Fast path: for simple DTOs (no hidden props, no naming conventions),
+        // compare serialized arrays directly instead of iterating via reflection.
+        $profile = ReflectionCache::getClassProfile(static::class);
+        if ($profile->canUseFastPath) {
+            return $this->array() === $other->array();
+        }
+
         $properties = ReflectionCache::getPublicProperties(static::class);
 
         foreach ($properties as $property) {

--- a/src/Traits/HasComparison.php
+++ b/src/Traits/HasComparison.php
@@ -29,11 +29,9 @@ trait HasComparison
             return false;
         }
 
-        // Fast path: for simple DTOs (no hidden props, no naming conventions),
-        // compare serialized arrays directly instead of iterating via reflection.
         $profile = ReflectionCache::getClassProfile(static::class);
         if ($profile->canUseFastPath) {
-            return $this->array() === $other->array();
+            return $profile->areEqual($this, $other);
         }
 
         $properties = ReflectionCache::getPublicProperties(static::class);

--- a/src/Traits/HasDeserialization.php
+++ b/src/Traits/HasDeserialization.php
@@ -104,6 +104,15 @@ trait HasDeserialization
             return $result;
         }
 
+        $profile = ReflectionCache::getClassProfile(static::class);
+        if ($profile->canUseFastPath) {
+            $result = $profile->tryFastPath($args);
+            if (null !== $result) {
+                /** @var static $result */
+                return $result;
+            }
+        }
+
         // Check if args has string keys (named parameters)
         $hasStringKeys = ! empty(array_filter(array_keys($args), 'is_string'));
 

--- a/src/Traits/HasSerialization.php
+++ b/src/Traits/HasSerialization.php
@@ -58,6 +58,11 @@ trait HasSerialization
      */
     private function computeArray(): array
     {
+        $profile = ReflectionCache::getClassProfile(static::class);
+        if ($profile->canUseFastPath) {
+            return $profile->toArray($this);
+        }
+
         $result = [];
         $properties = ReflectionCache::getPublicProperties(static::class);
         $metadata = MetadataCache::getMetadata(static::class);

--- a/src/Traits/HasSerialization.php
+++ b/src/Traits/HasSerialization.php
@@ -53,45 +53,6 @@ trait HasSerialization
     }
 
     /**
-     * @return array Serialized array
-     * @throws SerializationException|ReflectionException
-     */
-    private function computeArray(): array
-    {
-        $profile = ReflectionCache::getClassProfile(static::class);
-        if ($profile->canUseFastPath) {
-            return $profile->toArray($this);
-        }
-
-        $result = [];
-        $properties = ReflectionCache::getPublicProperties(static::class);
-        $metadata = MetadataCache::getMetadata(static::class);
-
-        foreach ($properties as $property) {
-            $phpName = $property->getName();
-
-            // Skip hidden properties
-            if ($metadata->isHidden($phpName)) {
-                continue;
-            }
-
-            // Skip uninitialized properties
-            if ( ! $property->isInitialized($this)) {
-                continue;
-            }
-
-            $value = $property->getValue($this);
-            $serializedValue = $this->serializeValue($phpName, $value, $property);
-
-            // Use custom property name if defined (includes convention-applied names)
-            $serializedName = $metadata->getSerializedName($phpName);
-            $result[$serializedName] = $serializedValue;
-        }
-
-        return $result;
-    }
-
-    /**
      * @throws SerializationException|ReflectionException
      */
     public function json(): string
@@ -131,6 +92,45 @@ trait HasSerialization
     protected static function hiddenProperties(): array
     {
         return [];
+    }
+
+    /**
+     * @return array Serialized array
+     * @throws SerializationException|ReflectionException
+     */
+    private function computeArray(): array
+    {
+        $profile = ReflectionCache::getClassProfile(static::class);
+        if ($profile->canUseFastPath) {
+            return $profile->toArray($this);
+        }
+
+        $result = [];
+        $properties = ReflectionCache::getPublicProperties(static::class);
+        $metadata = MetadataCache::getMetadata(static::class);
+
+        foreach ($properties as $property) {
+            $phpName = $property->getName();
+
+            // Skip hidden properties
+            if ($metadata->isHidden($phpName)) {
+                continue;
+            }
+
+            // Skip uninitialized properties
+            if ( ! $property->isInitialized($this)) {
+                continue;
+            }
+
+            $value = $property->getValue($this);
+            $serializedValue = $this->serializeValue($phpName, $value, $property);
+
+            // Use custom property name if defined (includes convention-applied names)
+            $serializedName = $metadata->getSerializedName($phpName);
+            $result[$serializedName] = $serializedValue;
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Traits/HasSerialization.php
+++ b/src/Traits/HasSerialization.php
@@ -91,10 +91,18 @@ trait HasSerialization
      */
     public function json(): string
     {
+        $cached = SerializationCache::getJson($this);
+        if (null !== $cached) {
+            return $cached;
+        }
+
         $json = json_encode($this->array());
         if (false === $json) {
             throw new RuntimeException('Failed to encode object to JSON');
         }
+
+        SerializationCache::setJson($this, $json);
+
         return $json;
     }
 

--- a/src/Traits/HasSerialization.php
+++ b/src/Traits/HasSerialization.php
@@ -10,6 +10,7 @@ use Ninja\Granite\Exceptions\ReflectionException;
 use Ninja\Granite\Exceptions\SerializationException;
 use Ninja\Granite\Serialization\Attributes\DateTimeProvider;
 use Ninja\Granite\Serialization\MetadataCache;
+use Ninja\Granite\Serialization\SerializationCache;
 use Ninja\Granite\Support\CarbonSupport;
 use Ninja\Granite\Support\ReflectionCache;
 use Ninja\Granite\Transformers\CarbonTransformer;
@@ -32,12 +33,30 @@ trait HasSerialization
      * @return CarbonTransformer|null Carbon transformer or null
      */
     abstract protected static function getCarbonTransformerFromAttributes(?ReflectionProperty $property = null, ?DateTimeProvider $classProvider = null): ?CarbonTransformer;
+
     /**
      * @return array Serialized array
      * @throws RuntimeException If a property cannot be serialized
      * @throws SerializationException|ReflectionException
      */
     public function array(): array
+    {
+        $cached = SerializationCache::get($this);
+        if (null !== $cached) {
+            return $cached;
+        }
+
+        $result = $this->computeArray();
+        SerializationCache::set($this, $result);
+
+        return $result;
+    }
+
+    /**
+     * @return array Serialized array
+     * @throws SerializationException|ReflectionException
+     */
+    private function computeArray(): array
     {
         $result = [];
         $properties = ReflectionCache::getPublicProperties(static::class);

--- a/tests/Fixtures/DTOs/TeamDTO.php
+++ b/tests/Fixtures/DTOs/TeamDTO.php
@@ -1,0 +1,19 @@
+<?php
+
+// ABOUTME: Fixture for testing nested fast path - a DTO with a Granite-typed param.
+// ABOUTME: No attributes, no conventions - pure primitives + one nested Granite object.
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\DTOs;
+
+use Ninja\Granite\Granite;
+
+final readonly class TeamDTO extends Granite
+{
+    public function __construct(
+        public string $name,
+        public PersonDTO $leader,
+        public int $size,
+    ) {}
+}

--- a/tests/Unit/Serialization/MetadataCacheTest.php
+++ b/tests/Unit/Serialization/MetadataCacheTest.php
@@ -217,7 +217,6 @@ use Tests\Helpers\TestCase;
 
         if ($reflection->hasProperty('metadataCache')) {
             $cacheProperty = $reflection->getProperty('metadataCache');
-            $cacheProperty->setAccessible(true);
             $cacheProperty->setValue(null, []);
         }
     }

--- a/tests/Unit/Support/ClassProfileTest.php
+++ b/tests/Unit/Support/ClassProfileTest.php
@@ -1,0 +1,173 @@
+<?php
+
+// ABOUTME: Tests for ClassProfile fast-path detection and object creation.
+// ABOUTME: Verifies correct identification of simple DTOs and fast instantiation.
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support;
+
+use Ninja\Granite\Support\ClassProfile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Tests\Fixtures\DTOs\NestedDTO;
+use Tests\Fixtures\DTOs\PersonDTO;
+use Tests\Fixtures\DTOs\ScalarDTO;
+use Tests\Fixtures\DTOs\SimpleDTO;
+use Tests\Fixtures\DTOs\TestHiddenDto;
+use Tests\Fixtures\DTOs\TestSnakeCaseDto;
+use Tests\Fixtures\VOs\ValidatedUserVO;
+use Tests\Helpers\TestCase;
+
+#[CoversClass(ClassProfile::class)]
+class ClassProfileTest extends TestCase
+{
+    public function test_detects_fast_path_for_primitive_dto(): void
+    {
+        $profile = ClassProfile::build(PersonDTO::class);
+
+        $this->assertTrue($profile->canUseFastPath);
+    }
+
+    public function test_detects_fast_path_for_dto_with_all_scalar_types(): void
+    {
+        $profile = ClassProfile::build(ScalarDTO::class);
+
+        $this->assertTrue($profile->canUseFastPath);
+    }
+
+    public function test_rejects_fast_path_for_nested_object_types(): void
+    {
+        $profile = ClassProfile::build(NestedDTO::class);
+
+        $this->assertFalse($profile->canUseFastPath);
+    }
+
+    public function test_rejects_fast_path_for_validation_attributes(): void
+    {
+        $profile = ClassProfile::build(ValidatedUserVO::class);
+
+        $this->assertFalse($profile->canUseFastPath);
+    }
+
+    public function test_rejects_fast_path_for_serialization_convention(): void
+    {
+        $profile = ClassProfile::build(TestSnakeCaseDto::class);
+
+        $this->assertFalse($profile->canUseFastPath);
+    }
+
+    public function test_rejects_fast_path_for_hidden_attributes(): void
+    {
+        $profile = ClassProfile::build(TestHiddenDto::class);
+
+        $this->assertFalse($profile->canUseFastPath);
+    }
+
+    public function test_fast_path_with_array_data(): void
+    {
+        $profile = ClassProfile::build(PersonDTO::class);
+
+        $result = $profile->tryFastPath([['name' => 'Alice', 'age' => 30, 'email' => 'alice@test.com']]);
+
+        $this->assertInstanceOf(PersonDTO::class, $result);
+        $this->assertSame('Alice', $result->name);
+        $this->assertSame(30, $result->age);
+        $this->assertSame('alice@test.com', $result->email);
+    }
+
+    public function test_fast_path_with_named_params(): void
+    {
+        $profile = ClassProfile::build(PersonDTO::class);
+
+        $result = $profile->tryFastPath(['email' => 'bob@test.com', 'name' => 'Bob', 'age' => 25]);
+
+        $this->assertInstanceOf(PersonDTO::class, $result);
+        $this->assertSame('Bob', $result->name);
+        $this->assertSame(25, $result->age);
+        $this->assertSame('bob@test.com', $result->email);
+    }
+
+    public function test_fast_path_falls_back_when_optional_params_missing(): void
+    {
+        $profile = ClassProfile::build(SimpleDTO::class);
+
+        $result = $profile->tryFastPath([['id' => 1, 'name' => 'Test', 'email' => 'test@test.com']]);
+
+        $this->assertNull($result);
+    }
+
+    public function test_fast_path_works_when_all_params_provided(): void
+    {
+        $profile = ClassProfile::build(SimpleDTO::class);
+
+        $result = $profile->tryFastPath([['id' => 1, 'name' => 'Test', 'email' => 'test@test.com', 'age' => 25]]);
+
+        $this->assertInstanceOf(SimpleDTO::class, $result);
+        $this->assertSame(1, $result->id);
+        $this->assertSame(25, $result->age);
+    }
+
+    public function test_fast_path_returns_null_for_missing_required_param(): void
+    {
+        $profile = ClassProfile::build(PersonDTO::class);
+
+        $result = $profile->tryFastPath([['name' => 'Alice']]);
+
+        $this->assertNull($result);
+    }
+
+    public function test_fast_path_returns_null_for_json_string(): void
+    {
+        $profile = ClassProfile::build(PersonDTO::class);
+
+        $result = $profile->tryFastPath(['{"name":"Alice","age":30,"email":"a@b.com"}']);
+
+        $this->assertNull($result);
+    }
+
+    public function test_fast_path_returns_null_for_object_input(): void
+    {
+        $profile = ClassProfile::build(PersonDTO::class);
+        $source = PersonDTO::from(name: 'Alice', age: 30, email: 'a@b.com');
+
+        $result = $profile->tryFastPath([$source]);
+
+        $this->assertNull($result);
+    }
+
+    public function test_fast_path_produces_identical_results_to_slow_path(): void
+    {
+        $data = ['name' => 'Alice', 'age' => 30, 'email' => 'alice@test.com'];
+        $profile = ClassProfile::build(PersonDTO::class);
+
+        $fast = $profile->tryFastPath([$data]);
+        $slow = PersonDTO::from($data);
+
+        $this->assertNotNull($fast);
+        $this->assertEquals($slow->array(), $fast->array());
+    }
+
+    public function test_fast_path_with_all_scalar_types(): void
+    {
+        $data = ['id' => 1, 'name' => 'Product', 'price' => 9.99, 'active' => true, 'tags' => ['a', 'b']];
+        $profile = ClassProfile::build(ScalarDTO::class);
+
+        $result = $profile->tryFastPath([$data]);
+
+        $this->assertInstanceOf(ScalarDTO::class, $result);
+        $this->assertSame(1, $result->id);
+        $this->assertSame('Product', $result->name);
+        $this->assertSame(9.99, $result->price);
+        $this->assertTrue($result->active);
+        $this->assertSame(['a', 'b'], $result->tags);
+    }
+
+    public function test_fast_path_returns_null_for_positional_args(): void
+    {
+        $profile = ClassProfile::build(PersonDTO::class);
+
+        $result = $profile->tryFastPath(['Alice', 30, 'a@b.com']);
+
+        $this->assertNull($result);
+    }
+}

--- a/tests/Unit/Support/ClassProfileTest.php
+++ b/tests/Unit/Support/ClassProfileTest.php
@@ -13,6 +13,7 @@ use Tests\Fixtures\DTOs\NestedDTO;
 use Tests\Fixtures\DTOs\PersonDTO;
 use Tests\Fixtures\DTOs\ScalarDTO;
 use Tests\Fixtures\DTOs\SimpleDTO;
+use Tests\Fixtures\DTOs\TeamDTO;
 use Tests\Fixtures\DTOs\TestHiddenDto;
 use Tests\Fixtures\DTOs\TestSnakeCaseDto;
 use Tests\Fixtures\VOs\ValidatedUserVO;
@@ -169,5 +170,77 @@ class ClassProfileTest extends TestCase
         $result = $profile->tryFastPath(['Alice', 30, 'a@b.com']);
 
         $this->assertNull($result);
+    }
+
+    public function test_detects_fast_path_for_nested_granite_types(): void
+    {
+        $profile = ClassProfile::build(TeamDTO::class);
+
+        $this->assertTrue($profile->canUseFastPath);
+    }
+
+    public function test_tracks_granite_typed_params(): void
+    {
+        $profile = ClassProfile::build(TeamDTO::class);
+
+        $this->assertArrayHasKey('leader', $profile->graniteParams);
+        $this->assertSame(PersonDTO::class, $profile->graniteParams['leader']);
+    }
+
+    public function test_pure_primitive_dto_has_empty_granite_params(): void
+    {
+        $profile = ClassProfile::build(PersonDTO::class);
+
+        $this->assertEmpty($profile->graniteParams);
+    }
+
+    public function test_fast_path_nested_with_array_data(): void
+    {
+        $profile = ClassProfile::build(TeamDTO::class);
+
+        $result = $profile->tryFastPath([[
+            'name' => 'Alpha',
+            'leader' => ['name' => 'Alice', 'age' => 30, 'email' => 'alice@test.com'],
+            'size' => 5,
+        ]]);
+
+        $this->assertInstanceOf(TeamDTO::class, $result);
+        $this->assertSame('Alpha', $result->name);
+        $this->assertSame(5, $result->size);
+        $this->assertInstanceOf(PersonDTO::class, $result->leader);
+        $this->assertSame('Alice', $result->leader->name);
+        $this->assertSame(30, $result->leader->age);
+    }
+
+    public function test_fast_path_nested_with_granite_instance(): void
+    {
+        $profile = ClassProfile::build(TeamDTO::class);
+        $leader = PersonDTO::from(name: 'Bob', age: 25, email: 'bob@test.com');
+
+        $result = $profile->tryFastPath([[
+            'name' => 'Beta',
+            'leader' => $leader,
+            'size' => 3,
+        ]]);
+
+        $this->assertInstanceOf(TeamDTO::class, $result);
+        $this->assertSame('Bob', $result->leader->name);
+    }
+
+    public function test_fast_path_nested_produces_identical_results_to_slow_path(): void
+    {
+        $data = [
+            'name' => 'Gamma',
+            'leader' => ['name' => 'Charlie', 'age' => 35, 'email' => 'charlie@test.com'],
+            'size' => 10,
+        ];
+
+        $fast = TeamDTO::from($data);
+        // Force slow path by going through full hydration
+        $profile = ClassProfile::build(TeamDTO::class);
+        $fastDirect = $profile->tryFastPath([$data]);
+
+        $this->assertNotNull($fastDirect);
+        $this->assertEquals($fast->array(), $fastDirect->array());
     }
 }


### PR DESCRIPTION
## Summary

- **Multi-layer fast path system** for simple DTOs: bypasses full hydration pipeline (reflection, metadata, type conversion) when all constructor params are primitives or Granite subclasses (~3.5x vs plain PHP)
- **WeakMap caching** for `array()` and `json()` — near-native speed on repeated calls
- **Direct property access** for serialization and comparison instead of reflection
- **O(1) hidden property lookups** via `Metadata::isHidden()` optimization
- **Fast path for `equals()`** with early exit on first difference
- **Nested fast path** — recursively applies optimizations to Granite-typed properties
- **README reorganized** from ~900 to ~234 lines as a concise landing page, removing content already covered in `docs/`

## Benchmarks

| Operation | vs Plain PHP |
|-----------|:------------:|
| `from(array)` simple DTO | 3.5x |
| `from(array)` nested (3 objects) | 4.6x |
| `array()` serialization | 1.3x |
| `json()` serialization | 1.0x |
| `equals()` comparison | 4.0x |
| Property access | 0x (identical) |

## Test plan

- [x] All 1976 tests passing
- [x] PHPStan level 10 clean
- [x] Code style (Pint) passing
- [x] All docs/ links verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured README with renewed emphasis on Pebble as the lightweight immutable snapshot tool.
  * Updated usage examples to reflect Pebble-centric patterns and removed legacy snippets.
  * Added performance benchmarks comparing Pebble, Granite, and plain PHP implementations.

* **Deprecations**
  * Marked GraniteDTO and GraniteVO for deprecation with migration guidance provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->